### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ TvOSScribble, based on CoreML, mitigates the lack of a physical numpad area in S
 
 ## Installation
 
-### Cocoapods
+### CocoaPods
 
 To integrate TvOSScribble into your Xcode project using CocoaPods, specify it in your `Podfile`:
 


### PR DESCRIPTION

This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).
